### PR TITLE
Add staging models

### DIFF
--- a/_project_docs/terminal_snipps.txt
+++ b/_project_docs/terminal_snipps.txt
@@ -1,0 +1,4 @@
+----------------------------- FOR THE TERMINAL DO NOT ADD-------------------------------
+ls | awk '{print "- name: " $0}'
+ls | sed "s/^/* \`/; s/$/\`/" 
+ls | awk '{print "* `" $0 "`"}'

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -23,15 +23,7 @@ clean-targets:         # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 
-
-# Configuring models
-# Full documentation: https://docs.getdbt.com/docs/configuring-models
-
-# In this example config, we tell dbt to build all models in the example/
-# directory as views. These settings can be overridden in the individual model
-# files using the `{{ config(...) }}` macro.
 models:
   dbt_retail:
-    # Config indicated by + and applies to all files under models/example/
-    example:
+    staging:
       +materialized: view

--- a/models/staging/retail/_retail__models.yml
+++ b/models/staging/retail/_retail__models.yml
@@ -1,0 +1,18 @@
+version: 2
+
+models:
+  - name: stg_retail__addresses
+  - name: stg_retail__cities
+  - name: stg_retail__countries
+  - name: stg_retail__customers
+  - name: stg_retail__employees
+  - name: stg_retail__order_lines
+  - name: stg_retail__package_types
+  - name: stg_retail__payment_types
+  - name: stg_retail__product_categories
+  - name: stg_retail__product_departments
+  - name: stg_retail__product_subcategories
+  - name: stg_retail__products
+  - name: stg_retail__promotions
+  - name: stg_retail__provinces
+  - name: stg_retail__units_of_measure

--- a/models/staging/retail/_retail__sources.yml
+++ b/models/staging/retail/_retail__sources.yml
@@ -1,0 +1,22 @@
+version: 2
+
+sources:
+  - name: retail
+    database: retail_raw
+    schema: retail
+    tables:
+      - name: addresses
+      - name: customers
+      - name: orderlines
+      - name: provinces
+      - name: products
+      - name: cities
+      - name: countries
+      - name: paymenttypes
+      - name: promotions
+      - name: packagetypes
+      - name: employees
+      - name: productcategories
+      - name: unitsofmeasure
+      - name: productdepartments
+      - name: productsubcategories

--- a/models/staging/retail/stg_retail__addresses.sql
+++ b/models/staging/retail/stg_retail__addresses.sql
@@ -1,0 +1,21 @@
+with
+
+addresses as (
+
+    select * from {{ source('retail', 'addresses') }}
+
+),
+
+final as (
+
+	SELECT [AddressID] AS addressid
+	      ,[AddressLine1] AS address_line1
+	      ,[AddressLine2] AS address_line2
+	      ,[CityID] AS cityid
+	      ,[PostalCode] AS postal_code
+	      ,[ModifiedDate]AS modified_date
+	  FROM addresses
+
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__cities.sql
+++ b/models/staging/retail/stg_retail__cities.sql
@@ -1,0 +1,19 @@
+with
+
+cities as (
+
+    select * from {{ source('retail', 'cities') }}
+
+),
+
+final as (
+
+	SELECT [CityID] AS cityid
+	      ,[CityName] AS city_name
+	      ,[ProvinceID] AS provinceid
+	      ,[Population] AS population
+	      ,[ModifiedDate] AS modified_date
+	  FROM cities
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__countries.sql
+++ b/models/staging/retail/stg_retail__countries.sql
@@ -1,0 +1,23 @@
+with
+
+countries as (
+
+    select * from {{ source('retail', 'countries') }}
+
+),
+
+final as (
+
+	SELECT [CountryID] AS countryid
+	      ,[CountryName] AS Country_name
+	      ,[FormalName]AS formal_name
+	      ,[CountryCode] AS country_code
+	      ,[Population] AS population
+	      ,[Continent] AS contient
+	      ,[Region] AS region
+	      ,[Subregion] AS subregion
+	      ,[ModifiedDate] AS modified_date
+	  FROM countries
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__customers.sql
+++ b/models/staging/retail/stg_retail__customers.sql
@@ -1,0 +1,24 @@
+with
+
+customers as (
+
+    select * from {{ source('retail', 'customers') }}
+
+),
+
+final as (
+
+	SELECT [CustomerID] 			AS customerid
+	      ,[FirstName] 				AS first_name
+	      ,[LastName] 				AS last_name
+	      ,[FullName]				AS full_name
+	      ,[Title]					AS title
+	      ,[DeliveryAddressID]		AS delivery_addressid
+	      ,[BillingAddressID]		AS billing_addressid
+	      ,[PhoneNumber]			AS phone_number
+	      ,[Email]					AS email	
+	      ,[ModifiedDate]			AS modified_date
+	FROM  customers
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__employees.sql
+++ b/models/staging/retail/stg_retail__employees.sql
@@ -1,0 +1,26 @@
+
+with
+
+employees as (
+
+    select * from {{ source('retail', 'employees') }}
+
+),
+
+final as (
+
+	SELECT [EmployeeID] 			AS employeeid
+	      ,[FirstName] 				AS first_name
+	      ,[LastName] 				AS last_name
+	      ,[Title]					AS title
+		  ,[BirthDate]				AS birth_date
+		  ,[Gender]					AS gender
+		  ,[HireDate]				AS hire_date
+		  ,[JobTitle]				AS job_title
+		  ,[AddressID]				AS addressid
+		  ,[ManagerID]				AS manager_key
+		  ,[ModifiedDate]			AS modified_date
+   FROM employees
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__order_lines.sql
+++ b/models/staging/retail/stg_retail__order_lines.sql
@@ -1,0 +1,28 @@
+
+with
+
+order_lines as (
+
+    select * from {{ source('retail', 'orderlines') }}
+
+),
+
+final as (
+
+	SELECT [OrderLineID] 			AS order_lineid
+	      ,[OrderID]				AS orderid
+	      ,[ProductID]				AS productid
+	      ,[PackageTypeID]			AS package_typeid
+	      ,[PromotionID]			AS promotionid
+	      ,[InventoryItemID]		AS inventory_itemid
+	      ,[UnitPrice]				AS unit_price
+	      ,[Description]			AS description
+	      ,[Quantity] 				AS quantity
+	      ,[Discount]				AS discount
+	      ,[ModifiedDate]			AS modified_date
+	      ,[LineNumber]				AS line_number
+	      ,[VATRate]				AS vat_rate
+	  FROM order_lines
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__package_types.sql
+++ b/models/staging/retail/stg_retail__package_types.sql
@@ -1,0 +1,18 @@
+
+with
+
+package_types as (
+
+    select * from {{ source('retail', 'packagetypes') }}
+
+),
+
+final as (
+
+	SELECT [PackageTypeID] 		AS package_typeid
+	      ,[PackageTypeName]	AS package_type_name
+	      ,[ModifiedDate]		AS modified_date
+	  FROM package_types
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__payment_types.sql
+++ b/models/staging/retail/stg_retail__payment_types.sql
@@ -1,0 +1,18 @@
+
+with
+
+payment_types as (
+
+    select * from {{ source('retail', 'paymenttypes') }}
+
+),
+
+final as (
+
+	SELECT [PaymentTypeID] 		AS payment_typeid
+	      ,[PaymentTypeName]	AS payment_type_name
+	      ,[ModifiedDate]		AS modified_date
+	FROM payment_types
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__product_categories.sql
+++ b/models/staging/retail/stg_retail__product_categories.sql
@@ -1,0 +1,20 @@
+
+with
+
+product_categories as (
+
+    select * from {{ source('retail', 'productcategories') }}
+
+),
+
+final as (
+
+	SELECT [CategoryID] 			AS categoryid
+	      ,[CategoryName]			AS category_name
+	      ,[CategoryDescription]	AS category_description
+	      ,[DepartmentID]			AS departmentid
+	      ,[ModifiedDate]			AS modified_date
+	  FROM product_categories
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__product_departments.sql
+++ b/models/staging/retail/stg_retail__product_departments.sql
@@ -1,0 +1,19 @@
+
+with
+
+product_departments as (
+
+    select * from {{ source('retail', 'productdepartments') }}
+
+),
+
+final as (
+
+	SELECT [DepartmentID]	AS departmentid
+	      ,[Name]			AS name
+	      ,[Description]	AS description
+	      ,[ModifiedDate]	AS modified_date
+	FROM product_departments
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__product_subcategories.sql
+++ b/models/staging/retail/stg_retail__product_subcategories.sql
@@ -1,0 +1,20 @@
+
+with
+
+product_subcategories as (
+
+    select * from {{ source('retail', 'productsubcategories') }}
+
+),
+
+final as (
+
+	SELECT [ProductSubcategoryID] 		AS product_subcategoryid
+	      ,[ProductCategoryID]			AS product_categoryid
+	      ,[SubcategoryName]			AS subcategories_name
+	      ,[SubcategoryDescription]		AS subcategory_description
+	      ,[ModifiedDate]				AS modified_date
+	FROM product_subcategories
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__products.sql
+++ b/models/staging/retail/stg_retail__products.sql
@@ -1,0 +1,24 @@
+
+with
+
+products as (
+
+    select * from {{ source('retail', 'products') }}
+
+),
+
+final as (
+
+	SELECT [ProductID]				AS productid
+	      ,[ProductName]			AS product_name
+	      ,[ProductCode]			AS product_code
+	      ,[ProductDescription]		AS product_description
+	      ,[SubcategoryID]			AS subcategoryid
+	      ,[UnitOfMeasureID]		AS unit_of_measureID
+	      ,[UnitPrice]				AS unit_price
+	      ,[Discontinued]			AS discontinued
+	      ,[ModifiedDate]			AS modified_date
+	FROM products
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__promotions.sql
+++ b/models/staging/retail/stg_retail__promotions.sql
@@ -1,0 +1,22 @@
+
+with
+
+promotions as (
+
+    select * from {{ source('retail', 'promotions') }}
+
+),
+
+final as (
+
+	SELECT PromotionID		AS promotionid,
+	      DealDescription	AS deal_description,	
+	      StartDate			AS start_date,
+	      EndDate			AS end_date,
+	      DiscountAmount	AS discount_amount,
+	      DiscountPercentage AS discount_percentage,
+	      ModifiedDate		AS modified_date,
+	FROM promotions
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__provinces.sql
+++ b/models/staging/retail/stg_retail__provinces.sql
@@ -1,0 +1,22 @@
+
+
+with
+
+provinces as (
+
+    select * from {{ source('retail', 'provinces') }}
+
+),
+
+final as (
+
+	SELECT [ProvinceID]		AS provinceid
+	      ,[ProvinceCode]	AS province_code
+	      ,[ProvinceName]	AS province_name
+	      ,[CountryID]		AS countryid
+	      ,[Population]		AS population
+	      ,[ModifiedDate]	AS modified_date
+	 FROM provinces
+)
+
+select * from final

--- a/models/staging/retail/stg_retail__units_of_measure.sql
+++ b/models/staging/retail/stg_retail__units_of_measure.sql
@@ -1,0 +1,20 @@
+
+
+with
+
+units_of_measure as (
+
+    select * from {{ source('retail', 'unitsofmeasure') }}
+
+),
+
+final as (
+
+	SELECT [UnitOfMeasureID] AS units_of_measureid
+	      ,[UnitMeasureCode] AS units_measure_code	
+	      ,[Name]			 AS name
+	      ,[ModifiedDate]	 AS modified_date
+	FROM units_of_measure
+)
+
+select * from final

--- a/profiles.yml
+++ b/profiles.yml
@@ -1,69 +1,7 @@
-cloud_transform_dbt:
-  outputs:
-    dev:
-      account: th58624.east-us-2.azure
-      database: ANALYTICS_DEV
-      password: Rassman123
-      role: TRANSFORM_ROLE
-      schema: DBT_SBROWN
-      threads: 4
-      type: snowflake
-      user: TRANSFORM_USER
-      warehouse: TRANSFORM_WH
-    prod:
-      account: th58624.east-us-2.azure
-      database: ANALYTICS
-      password: Rassman123
-      role: TRANSFORM_ROLE
-      schema: DBT_SBROWN
-      threads: 4
-      type: snowflake
-      user: TRANSFORM_USER
-      warehouse: TRANSFORM_WH
-  target: dev
-dbtSnowflake_Healthcare:
-  outputs:
-    dev:
-      account: shxnusq-bbb65355
-      database: HEALTH_DATA_DEV
-      password: '@Password78!'
-      role: ACCOUNTADMIN
-      schema: DBT_HEALTH
-      threads: 1
-      type: snowflake
-      user: rayboy
-      warehouse: COMPUTE_WH
-  target: dev
-dbt_claims:
-  outputs:
-    dev:
-      account: shxnusq-bbb65355
-      database: claims_analytics
-      password: OneBlood123
-      role: developer
-      schema: dbt_brown
-      threads: 4
-      type: snowflake
-      user: transform_user
-      warehouse: healthcare_wh
-  target: dev
-dbt_health:
-  outputs:
-    dev:
-      account: shxnusq-bbb65355
-      database: HEALTHCARE_DEV
-      password: OneBlood123
-      role: DEVELOPER
-      schema: dbt_sjbrown
-      threads: 2
-      type: snowflake
-      user: TRANSFORM_USER
-      warehouse: HEALTHCARE_WH
-  target: dev
 dbt_retail:
   outputs:
     dev:
-      account: shxnusq-bbb65355
+      account: xub44819.us-east-1
       database: RETAIL_DEV
       password: OneBlood123
       role: DEVELOPER


### PR DESCRIPTION
Add Sources and Staging Models

### Summary
Add initial `sources` and `staging` models 

### Details
* Added the following `staging/retail/` models based on the source system
   * **retail**
	  * `stg_retail__addresses.sql`
	  * `stg_retail__cities.sql`
	  * `stg_retail__countries.sql`
	  * `stg_retail__customers.sql`
	  * `stg_retail__employees.sql`
	  * `stg_retail__order_lines.sql`
	  * `stg_retail__package_types.sql`
	  * `stg_retail__payment_types.sql`
	  * `stg_retail__product_categories.sql`
	  * `stg_retail__product_departments.sql`
	  * `stg_retail__product_subcategories.sql`
	  * `stg_retail__products.sql`
	  * `stg_retail__promotions.sql`
	  * `stg_retail__provinces.sql`
	  * `stg_retail__units_of_measure.sql`
	
### Data not loaded
- [x] stg_retail__units_of_measure.sq
### Checks
- [x] Follows style guide
- [x] Tested changes

### References
* [Source Properties](https://docs.getdbt.com/reference/source-properties)
* [Model Properties](https://docs.getdbt.com/reference/model-properties)


